### PR TITLE
Add custom settings for days off

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject clanhr/work-days "0.1.0"
+(defproject clanhr/work-days "0.3.0"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
-  :dependencies [[org.clojure/clojure "1.8.0-RC2"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [clj-time "0.11.0"]])

--- a/src/clanhr/work_days/core.cljc
+++ b/src/clanhr/work_days/core.cljc
@@ -5,17 +5,25 @@
             [clj-time.coerce :as c]
             [clj-time.core :as t]))
 
+(defn- absence-type
+  "Gets the absence type"
+  [absence]
+  (or (:absence-type absence)
+      (:type absence)))
+
 (defn- build-date
   "Creates a joda date from string"
   [absence field]
   (assoc absence field (c/from-string (field absence))))
 
-(defn- build
+(defn build
   "Prepares an absence"
   [absence]
    (cond-> absence
      (nil? (:duration-type absence)) (assoc :duration-type "days")
      (string? (:start-date absence)) (build-date :start-date)
+     (instance? java.sql.Date (:start-date absence)) (assoc :start-date (c/from-sql-date (:start-date absence)))
+     (instance? java.sql.Date (:end-date absence)) (assoc :end-date (c/from-sql-date (:end-date absence)))
      (nil? (:end-date absence)) (assoc :end-date (:start-date absence))
      (string? (:end-date absence)) (build-date :end-date)))
 
@@ -36,19 +44,27 @@
   (take (days-interval settings absence)
         (p/periodic-seq (:start-date absence) (t/days 1))))
 
+(defn work-day?
+  "True if the given day is a work day, based on the settings"
+  [settings day]
+  (if-let [days-off (:days-off settings)]
+    (let [week-day (t/day-of-week day)]
+      (not (some #{week-day} days-off)))
+    (pr/weekday? day)))
+
 (defn days-interval-remove-dayoff
   "Gets the number of days between start-date and end-date, removing the
   dayoffs defined on the settings"
   [settings absence]
   (->> (absence->days-coll settings absence)
-       (filter pr/weekday?)
+       (filter (fn [day]  (work-day? settings day)))
        count))
 
 (defn total-vacation-days
   "Gets the total vacation days on this absence"
   [settings absence]
   (let [absence (build absence)]
-    (if (= "vacations" (:absence-type absence))
+    (if (= "vacations" (absence-type absence))
       (days-interval-remove-dayoff settings absence)
       0)))
 
@@ -56,7 +72,7 @@
   "Gets the total vacation days on this absence"
   [settings absence]
   (let [absence (build absence)]
-    (if (not= "vacations" (:absence-type absence))
+    (if (not= "vacations" (absence-type absence))
       (if (= "days" (:duration-type absence))
         (* (hours-per-day settings)
            (days-interval settings absence))
@@ -66,10 +82,12 @@
 (defn calculate
   "Gets the raw duration of the absence, in days or hours, depending on the
   duration type"
-  [settings absence]
-  (let [absence (build absence)]
-    (if (= (:duration-type absence) "days")
-      (if (= (:absence-type absence) "vacations")
-        (days-interval-remove-dayoff settings absence)
-        (days-interval settings absence))
-      (:hours absence))))
+  ([absence]
+   (calculate {} absence))
+  ([settings absence]
+   (let [absence (build absence)]
+     (if (= (:duration-type absence) "days")
+       (if (= (absence-type absence) "vacations")
+         (days-interval-remove-dayoff settings absence)
+         (days-interval settings absence))
+       (:hours absence)))))

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -1,6 +1,7 @@
 (ns clanhr.work-days.core-test
   (:require [clojure.test :refer :all]
-            [clanhr.work-days.core :as work-days]))
+            [clanhr.work-days.core :as work-days]
+            [clj-time.core :as t]))
 
 (deftest default-week-vacation-days
   (let [absence {:start-date "2015-11-09"
@@ -20,3 +21,61 @@
       (let [absence (assoc absence :end-date "2015-11-15")]
         (is (= 5 (work-days/calculate {} absence)))
         (is (= 5 (work-days/total-vacation-days {} absence)))))))
+
+(deftest full-week-work-days
+  (let [absence {:start-date "2015-11-09"
+                 :end-date "2015-11-13"
+                 :absence-type "vacations"}
+        settings {:days-off []}]
+
+    (testing "default duration with 5 days"
+      (is (= 5 (work-days/calculate settings absence)))
+      (is (= 5 (work-days/total-vacation-days settings absence))))
+
+    (testing "should count weekend for non-vacation absences"
+      (let [absence (assoc absence :end-date "2015-11-15"
+                                   :absence-type "family")]
+        (is (= 7 (work-days/calculate settings absence)))))
+
+    (testing "should count weekend for absences"
+      (let [absence (assoc absence :end-date "2015-11-15")]
+        (is (= 7 (work-days/calculate settings absence)))
+        (is (= 7 (work-days/total-vacation-days settings absence)))))))
+
+(def monday (t/date-time 2016 2 1))
+(def tuesday (t/date-time 2016 2 2))
+(def wednesday (t/date-time 2016 2 3))
+(def thursday (t/date-time 2016 2 4))
+(def friday (t/date-time 2016 2 5))
+(def saturday (t/date-time 2016 2 6))
+(def sunday (t/date-time 2016 2 7))
+
+(deftest work-day-test?
+  (testing "default work week"
+    (is (true? (work-days/work-day? {} monday)))
+    (is (true? (work-days/work-day? {} tuesday)))
+    (is (true? (work-days/work-day? {} wednesday)))
+    (is (true? (work-days/work-day? {} thursday)))
+    (is (true? (work-days/work-day? {} friday)))
+    (is (false? (work-days/work-day? {} saturday)))
+    (is (false? (work-days/work-day? {} sunday))))
+
+  (testing "full work week"
+    (let [settings {:days-off []}]
+      (is (true? (work-days/work-day? settings monday)))
+      (is (true? (work-days/work-day? settings tuesday)))
+      (is (true? (work-days/work-day? settings wednesday)))
+      (is (true? (work-days/work-day? settings thursday)))
+      (is (true? (work-days/work-day? settings friday)))
+      (is (true? (work-days/work-day? settings saturday)))
+      (is (true? (work-days/work-day? settings sunday)))))
+
+  (testing "rest on mondays"
+    (let [settings {:days-off [1]}]
+      (is (false? (work-days/work-day? settings monday)))
+      (is (true? (work-days/work-day? settings tuesday)))
+      (is (true? (work-days/work-day? settings wednesday)))
+      (is (true? (work-days/work-day? settings thursday)))
+      (is (true? (work-days/work-day? settings friday)))
+      (is (true? (work-days/work-day? settings saturday)))
+      (is (true? (work-days/work-day? settings sunday))))))


### PR DESCRIPTION
Now it's possible to pass a `:days-off` param with an integer vector
with the numbers of week days that are day off (monday is 1). By default
saturday and sunday are days off.

clanhr/mothership#894