### PR TITLE
Total absence hours should consider settings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/work-days "0.7.1"
+(defproject clanhr/work-days "0.7.2"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clanhr/work_days/core.cljc
+++ b/src/clanhr/work_days/core.cljc
@@ -123,8 +123,9 @@
   (let [absence (build absence)]
     (if (not= "vacations" (absence-type absence))
       (if (= "days" (:duration-type absence))
-        (* (hours-per-day settings)
-           (days-interval settings absence))
+        (if (remove-days-off? settings absence)
+          (* (hours-per-day settings) (days-interval-remove-dayoff settings absence))
+          (* (hours-per-day settings) (days-interval settings absence)))
         (:hours absence))
       0)))
 
@@ -136,7 +137,7 @@
   ([settings absence]
    (let [absence (build absence)]
      (if (= (:duration-type absence) "days")
-       (if (doto (remove-days-off? settings absence))
+       (if (remove-days-off? settings absence)
          (days-interval-remove-dayoff settings absence)
          (days-interval settings absence))
        (:hours absence)))))

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -138,3 +138,16 @@
       (is (= 2 (work-days/calculate settings absence)))
       (is (= 2 (work-days/total-vacation-days settings absence))))))
 
+(deftest count-absences-by-settings
+  (let [absence {:start-date "2016-01-01"
+                 :end-date "2016-01-02"
+                 :absence-type "something"}
+        settings {:absences [{:label "something" :consider-days-off true}]
+                  :work-days {:days-off []
+                              :holidays [{:name "New Year"
+                                          :day "2016-01-01"
+                                          :recur true}]}}]
+
+    (testing "should count holiday"
+      (is (= 8 (work-days/total-absence-hours settings absence))))))
+


### PR DESCRIPTION
We can have absences that only count useful days, removing holidays and
weekends for example. The absence hours counter should consider these
settings.