### PR TITLE
Allow partial vacation days

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/work-days "0.7.2"
+(defproject clanhr/work-days "0.8.0"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clanhr/work_days/core.cljc
+++ b/src/clanhr/work_days/core.cljc
@@ -114,7 +114,9 @@
   [settings absence]
   (let [absence (build absence)]
     (if (= "vacations" (absence-type absence))
-      (days-interval-remove-dayoff settings absence)
+      (if (= (:duration-type absence) "partial-day")
+        (:partial-day absence)
+        (days-interval-remove-dayoff settings absence))
       0)))
 
 (defn total-absence-hours
@@ -136,8 +138,13 @@
    (calculate {} absence))
   ([settings absence]
    (let [absence (build absence)]
-     (if (= (:duration-type absence) "days")
-       (if (remove-days-off? settings absence)
-         (days-interval-remove-dayoff settings absence)
-         (days-interval settings absence))
-       (:hours absence)))))
+     (cond (= (:duration-type absence) "days")
+           (if (remove-days-off? settings absence)
+             (days-interval-remove-dayoff settings absence)
+             (days-interval settings absence))
+
+           (= (:duration-type absence) "partial-day")
+           (:partial-day absence)
+
+          :else
+          (:hours absence)))))

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -151,3 +151,14 @@
     (testing "should count holiday"
       (is (= 8 (work-days/total-absence-hours settings absence))))))
 
+(deftest half-vacation-days
+  (let [absence {:start-date "2015-11-09"
+                 :end-date "2015-11-09"
+                 :absence-type "vacations"
+                 :duration-type "partial-day"
+                 :partial-day 0.5}]
+
+    (testing "should consider half days"
+      (is (= 0.5 (work-days/calculate {} absence)))
+      (is (= 0.5 (work-days/total-vacation-days {} absence))))))
+


### PR DESCRIPTION
Add a new `duration-type` named `partial-day` that allows an extra fiel
to specify the percentage of the day (usually 0.5). This allows users to
take only half a day of vacations.

https://github.com/clanhr/mothership/issues/1222