### PR TITLE
Allow more date formats

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/work-days "0.8.0"
+(defproject clanhr/work-days "0.9.0"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -162,3 +162,10 @@
       (is (= 0.5 (work-days/calculate {} absence)))
       (is (= 0.5 (work-days/total-vacation-days {} absence))))))
 
+(deftest several-format-dates
+  (let [absence {:start-date "09-11-2015"
+                 :end-date "2015-11-09"
+                 :absence-type "vacations"}]
+
+      (is (= 1 (work-days/calculate {} absence)))
+      (is (= 1 (work-days/total-vacation-days {} absence)))))


### PR DESCRIPTION
When parsing a string to date, we were using `c/from-string`. And that
works fine for dates like `YYYY-MM-dd`. However, the new frontend now
sends dates in the format `dd-MM-YYYY` and the parsing returns a nil.

This patch, if the original parse is nil, will try other date formats.