### PR TITLE
Consider half-days on an absence

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/work-days "0.9.0"
+(defproject clanhr/work-days "0.10.0"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clanhr/work_days/core.cljc
+++ b/src/clanhr/work_days/core.cljc
@@ -131,7 +131,7 @@
       0)))
 
 (defn total-absence-hours
-  "Gets the total vacation days on this absence"
+  "Gets the total absence days/hours/partial-day on this absence"
   [settings absence]
   (let [absence (build absence)]
     (if (not= "vacations" (absence-type absence))
@@ -139,7 +139,9 @@
         (if (remove-days-off? settings absence)
           (* (hours-per-day settings) (days-interval-remove-dayoff settings absence))
           (* (hours-per-day settings) (days-interval settings absence)))
-        (:hours absence))
+        (if (= "partial-day" (:duration-type absence))
+          (:partial-day absence)
+          (:hours absence)))
       0)))
 
 (defn calculate

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -162,6 +162,17 @@
       (is (= 0.5 (work-days/calculate {} absence)))
       (is (= 0.5 (work-days/total-vacation-days {} absence))))))
 
+(deftest half-absence-days
+  (let [absence {:start-date "2015-11-09"
+                 :end-date "2015-11-09"
+                 :absence-type "medical"
+                 :duration-type "partial-day"
+                 :partial-day 0.5}]
+
+    (testing "should consider half days"
+      (is (= 0.5 (work-days/calculate {} absence)))
+      (is (= 0.5 (work-days/total-absence-hours {} absence))))))
+
 (deftest several-format-dates
   (let [absence {:start-date "09-11-2015"
                  :end-date "2015-11-09"


### PR DESCRIPTION
Why:

* Currently, only "vacations" can have half-days.
* We want other absences to allow half-days as well.

This change addresses the need by:

* Looking for the "partial-day" duration-type on the absence and returning it if it exists.