### PR TITLE
Consider hours for a half-day absence

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/work-days "0.10.0"
+(defproject clanhr/work-days "0.10.1"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clanhr/work_days/core.cljc
+++ b/src/clanhr/work_days/core.cljc
@@ -43,6 +43,11 @@
   [settings]
   (or (:hours-per-day settings) 8))
 
+(defn hours-in-half-day
+  "Gets the number of hours for a half working day"
+  [settings]
+  (/ (hours-per-day settings) 2))
+
 (defn days-interval
   "Gets the number of days between start-date and end-date"
   [settings absence]
@@ -140,7 +145,7 @@
           (* (hours-per-day settings) (days-interval-remove-dayoff settings absence))
           (* (hours-per-day settings) (days-interval settings absence)))
         (if (= "partial-day" (:duration-type absence))
-          (:partial-day absence)
+          (hours-in-half-day settings)
           (:hours absence)))
       0)))
 
@@ -157,7 +162,9 @@
              (days-interval settings absence))
 
            (= (:duration-type absence) "partial-day")
-           (:partial-day absence)
-
+           (if (= "vacations" (absence-type absence))
+             (:partial-day absence)
+             (hours-in-half-day settings))
+           
           :else
           (:hours absence)))))

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -170,8 +170,8 @@
                  :partial-day 0.5}]
 
     (testing "should consider half days"
-      (is (= 0.5 (work-days/calculate {} absence)))
-      (is (= 0.5 (work-days/total-absence-hours {} absence))))))
+      (is (= 4 (work-days/calculate {} absence)))
+      (is (= 4 (work-days/total-absence-hours {} absence))))))
 
 (deftest several-format-dates
   (let [absence {:start-date "09-11-2015"


### PR DESCRIPTION
Why:

* Absences (besides "vacations") are always counted in hours.

This change addresses the need by:

* Calculating a half-day in hours based on the hours of a total-day.

Notes:

* By default a total-day is 8 hours, hence a half-day will be 4 hours.