### PR TITLE
Get vacation days and absence hours from the absence

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/work-days "0.10.1"
+(defproject clanhr/work-days "0.11.0"
   :description "Work days calculation"
   :url "https://github.com/clanhr/work-days"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clanhr/work_days/core.cljc
+++ b/src/clanhr/work_days/core.cljc
@@ -149,6 +149,26 @@
           (:hours absence)))
       0)))
 
+(defn remove-vacation-days
+  "Gets vacation days based on the duration of the absence"
+  [absence]
+  (let [absence (build absence)]
+    (if (= "vacations" (absence-type absence))
+      (if (= (:duration-type absence) "partial-day")
+        (:partial-day absence)
+        (:duration absence))
+      0)))
+
+(defn remove-absence-hours
+  "Gets the total absence hours on this absence based on the duration"
+  [settings absence]
+  (let [absence (build absence)]
+    (if (not= "vacations" (absence-type absence))
+      (if (= "days" (:duration-type absence))
+        (* (hours-per-day settings) (:duration absence))
+        (:duration absence))
+      0)))
+
 (defn calculate
   "Gets the raw duration of the absence, in days or hours, depending on the
   duration type"

--- a/test/clanhr/work_days/core_test.cljc
+++ b/test/clanhr/work_days/core_test.cljc
@@ -180,3 +180,59 @@
 
       (is (= 1 (work-days/calculate {} absence)))
       (is (= 1 (work-days/total-vacation-days {} absence)))))
+
+(deftest remove-vacation-days
+  (let [absence {:start-date "2019-06-17"
+                 :end-date "2019-06-21"
+                 :absence-type "vacations"
+                 :duration-type "days"
+                 :duration 5}]
+
+    (testing "should remove 5 days"
+      (is (= 5 (work-days/calculate {} absence)))
+      (is (= 5 (work-days/remove-vacation-days absence))))))
+
+(deftest remove-vacation-days-partial-day
+  (let [absence {:start-date "2019-06-17"
+                 :end-date "2019-06-17"
+                 :absence-type "vacations"
+                 :duration-type "partial-day"
+                 :partial-day 0.5}]
+
+    (testing "should remove half day"
+      (is (= 0.5 (work-days/calculate {} absence)))
+      (is (= 0.5 (work-days/remove-vacation-days absence))))))
+
+(deftest remove-absence-days
+  (let [absence {:start-date "2019-06-17"
+                 :end-date "2019-06-18"
+                 :absence-type "medical"
+                 :duration-type "days"
+                 :duration 2}]
+
+    (testing "should remove 16 hours (2 days)"
+      (is (= 2 (work-days/calculate {} absence)))
+      (is (= (* 8 2) (work-days/remove-absence-hours {} absence))))))
+
+(deftest remove-absence-partial-day
+  (let [absence {:start-date "2019-06-17"
+                 :end-date "2019-06-17"
+                 :absence-type "medical"
+                 :duration-type "partial-day"
+                 :duration 4}]
+
+    (testing "should remove 4 hours (half day)"
+      (is (= 4 (work-days/calculate {} absence)))
+      (is (= 4 (work-days/remove-absence-hours {} absence))))))
+
+(deftest remove-absence-hours
+  (let [absence {:start-date "2019-06-17"
+                 :end-date "2019-06-17"
+                 :absence-type "medical"
+                 :duration-type "hours"
+                 :hours 3
+                 :duration 3}]
+
+    (testing "should remove 3 hours"
+      (is (= 3 (work-days/calculate {} absence)))
+      (is (= 3 (work-days/remove-absence-hours {} absence))))))


### PR DESCRIPTION
Why:

* When cancelling or reproving an absence, the duration of the absence should be given back to the user's counter bucket.
* The duration of the absence should be considered as it was when requested. When removing an absence, we will no longer calculate the duration based on settings (only when adding) because the employee could have changed country/region and have different holidays at the time the absence is being cancelled/reproved. Thus resulting in a different duration.

This change addresses the need by:

* Adding the 'remove-vacation-days' and 'remove-absence-hours' functions.
* These functions return the duration of the vacation (in days) or the absence (in hours), independent from the settings.